### PR TITLE
🔧 Add letter-spacing and font-weight to font-size variables filter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1016,6 +1016,8 @@ export function wordpressThemeJson(config: ThemeJsonConfig = {}): VitePlugin {
                               .filter(
                                   ([name]) =>
                                       !name.includes('line-height') &&
+                                      !name.includes('letter-spacing') &&
+                                      !name.includes('font-weight') &&
                                       !name.includes('shadow')
                               )
                               .map(([name, value]) => {


### PR DESCRIPTION
This PR provides support to set a default `letter-spacing` or `font-weight` value  for a `font-size` in your tailwind theme without it ending up as an entry in the `fontSizes` array in `theme.json`.

When providing a default `letter-spacing` or `font-weight` like:
```
--text-22: 1.375rem;
--text-22--line-height: 0.9;
--text-22--letter-spacing: -0.05em;
--text-22--font-weight: 700;
```
as per the [Tailwind Docs](https://tailwindcss.com/docs/font-size#customizing-your-theme), it would end up creating entries in the `theme.json` like:
```
{
  "name": "22--letter-spacing",
  "slug": "22--letter-spacing",
  "size": "-.05em"
},
```

Since `line-height` is currently already being filtered, i just added `letter-spacing` and `font-weight` to the filter conditions, resulting in a correctly generated `theme.json`.