### PR TITLE
Expand `exemptPackages` list with additional WordPress packages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -272,8 +272,20 @@ export function wordpressPlugin(
     const extensions = config.extensions ?? SUPPORTED_EXTENSIONS;
     const dependencies = new Set<string>();
 
-    // Do not rewrite imports or mark these packages as external
-    const exemptPackages = ['@wordpress/icons'];
+    /**
+    * Do not rewrite imports or mark these packages as external
+    * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dependency-extraction-webpack-plugin/lib/util.js
+    */
+    const exemptPackages = [
+        '@wordpress/dataviews',
+        '@wordpress/dataviews/wp',
+        '@wordpress/icons',
+        '@wordpress/interface',
+        '@wordpress/sync',
+        '@wordpress/undo-manager',
+        '@wordpress/upload-media',
+        '@wordpress/fields',
+    ];
 
     // HMR configuration with defaults
     const hmrConfig = {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -231,6 +231,17 @@ describe('wordpressPlugin', () => {
                 })
             );
         });
+
+        it('should not mark exempted WordPress packages as external', () => {
+            const result = (plugin.options as any)({
+                input: 'src/index.ts',
+            }) as InputOptions;
+
+            const external = result.external as (id: string) => boolean;
+
+            expect(external('@wordpress/icons')).toBe(false);
+            expect(external('@wordpress/dataviews')).toBe(false);
+        });
     });
 });
 


### PR DESCRIPTION
This change extends the work from #22 to cover additional packages that, are not available on the `window.wp` object and are expected to be bundled.