### PR TITLE
Fix/wordpress jsx runtime

### DIFF
--- a/src/externals/index.ts
+++ b/src/externals/index.ts
@@ -34,10 +34,12 @@ export function wordpressPlugin(config: WordPressPluginConfig = {}): VitePlugin 
         config() {
             if (config.jsx === false) return;
             return {
-                esbuild: {
-                    jsx: "transform" as const,
-                    jsxFactory: config.jsxFactory ?? "wp.element.createElement",
-                    jsxFragment: config.jsxFragment ?? "wp.element.Fragment",
+                oxc: {
+                    jsx: {
+                        runtime: "classic" as const,
+                        pragma: config.jsxFactory ?? "wp.element.createElement",
+                        pragmaFrag: config.jsxFragment ?? "wp.element.Fragment",
+                    },
                 },
             };
         },

--- a/src/externals/index.ts
+++ b/src/externals/index.ts
@@ -31,6 +31,17 @@ export function wordpressPlugin(config: WordPressPluginConfig = {}): VitePlugin 
         name: "wordpress-plugin",
         enforce: "pre",
 
+        config() {
+            if (config.jsx === false) return;
+            return {
+                esbuild: {
+                    jsx: "transform" as const,
+                    jsxFactory: config.jsxFactory ?? "wp.element.createElement",
+                    jsxFragment: config.jsxFragment ?? "wp.element.Fragment",
+                },
+            };
+        },
+
         options(opts: Rolldown.InputOptions) {
             return {
                 ...opts,

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,6 +198,25 @@ export interface WordPressPluginConfig {
     externalMappings?: Record<string, ExternalMapping>;
 
     /**
+     * Set to `false` to disable automatic JSX configuration.
+     */
+    jsx?: false;
+
+    /**
+     * JSX factory function.
+     *
+     * @default 'wp.element.createElement'
+     */
+    jsxFactory?: string;
+
+    /**
+     * JSX fragment identifier.
+     *
+     * @default 'wp.element.Fragment'
+     */
+    jsxFragment?: string;
+
+    /**
      * HMR configuration for the WordPress editor.
      */
     hmr?: {


### PR DESCRIPTION
### Problem

Projects using `wordpressPlugin()` with JSX block files fail to build under Vite 8 with:

```
Error: [vite]: Rolldown failed to resolve import "react/jsx-runtime" from "...block.jsx".
```

Oxc defaults to React's automatic JSX runtime and injects `import { jsx as _jsx } from 'react/jsx-runtime'` into every JSX file. WordPress block projects don't install `react` — they rely on `wp.element` — so this import can't be resolved and the build fails with a hard error.

### Context

I ran into this while upgrading a Sage project that includes a lot of jsx blocks in the theme, similar to what Radicle does. I was very confused because another project using the most recent version of Radicle doesn't have this issue. It turns out this issue was masked in Radicle because react gets pulled in by `@wordpress/icons`.

### What this PR does

Adds a `config()` hook to `wordpressPlugin` that switches the JSX transform to classic mode and points it at `wp.element`:

```ts
oxc: {
  jsx: {
    runtime: 'classic',
    pragma: 'wp.element.createElement',
    pragmaFrag: 'wp.element.Fragment',
  },
}
```

`runtime: 'classic'` disables the automatic JSX runtime import. `pragma` and `pragmaFrag` point JSX calls at `wp.element.createElement` and `wp.element.Fragment`, which are provided globally by WordPress.

Three new options are also added to `WordPressPluginConfig` for projects that need to override the defaults:

```ts
interface WordPressPluginConfig {
  jsx?: false;          // set to false to opt out of JSX configuration entirely
  jsxFactory?: string;  // default: 'wp.element.createElement'
  jsxFragment?: string; // default: 'wp.element.Fragment'
}
```

Happy to pull out this config override option if it seems unlikely to be used.

Also, although this seems like a sensible default, an alternative to this PR would be adding something like this to the vite config of each project:

```
// vite.config.js

oxc: {
  jsx: {
    runtime: 'classic',
    pragma: 'wp.element.createElement',
    pragmaFrag: 'wp.element.Fragment',
  },
}
```

&ast;&ast;Debugged with a lot of help from Claude